### PR TITLE
23/08: SoloQ con timer + validaciones + API /api/games con cálculo ELO

### DIFF
--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -1,16 +1,19 @@
 // app/api/games/route.ts
-import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
-import { getApps, initializeApp, cert, applicationDefault } from "firebase-admin/app";
-import { getAuth } from "firebase-admin/auth";
-import { hitLimit } from "@/lib/rateLimiter"; // ⬅️ asegúrate de tener este helper
+import { NextRequest, NextResponse } from "next/server"
+import { createClient } from "@supabase/supabase-js"
+import { getApps, initializeApp, cert, applicationDefault } from "firebase-admin/app"
+import { getAuth } from "firebase-admin/auth"
+import { hitLimit } from "@/lib/rateLimiter"
 
-// ✅ Init Firebase Admin (service account o ADC)
+// 👇 Asegura runtime Node (firebase-admin no funciona en Edge)
+export const runtime = "nodejs"
+
+// ✅ Init Firebase Admin (service account preferido; ADC como fallback local)
 if (!getApps().length) {
   const hasSA =
-    process.env.FIREBASE_PROJECT_ID &&
-    process.env.FIREBASE_CLIENT_EMAIL &&
-    process.env.FIREBASE_PRIVATE_KEY;
+    !!process.env.FIREBASE_PROJECT_ID &&
+    !!process.env.FIREBASE_CLIENT_EMAIL &&
+    !!process.env.FIREBASE_PRIVATE_KEY
 
   if (hasSA) {
     initializeApp({
@@ -19,296 +22,253 @@ if (!getApps().length) {
         clientEmail: process.env.FIREBASE_CLIENT_EMAIL!,
         privateKey: process.env.FIREBASE_PRIVATE_KEY!.replace(/\\n/g, "\n"),
       }),
-    });
+    })
   } else {
     initializeApp({
       credential: applicationDefault(),
-      projectId:
-        process.env.FIREBASE_PROJECT_ID ||
-        process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-    });
+      projectId: process.env.FIREBASE_PROJECT_ID || process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    })
   }
 }
 
+// 🗄️ Supabase con Service Role (solo en servidor)
 const supa = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
+)
 
 // Utils
-const clamp = (n: number, min: number, max: number) => Math.max(min, Math.min(max, n));
+const clamp = (n: number, min: number, max: number) => Math.max(min, Math.min(max, n))
 function calcEloDelta(oldElo: number, score: number, opponentElo = 1500, K = 32) {
-  const expected = 1 / (1 + Math.pow(10, (opponentElo - oldElo) / 400));
-  const delta = Math.round(K * (score - expected));
-  return clamp(delta, -40, 40); // clamp suave
+  const expected = 1 / (1 + Math.pow(10, (opponentElo - oldElo) / 400))
+  const delta = Math.round(K * (score - expected))
+  return clamp(delta, -40, 40) // límite suave
+}
+
+function json(res: any, status = 200, extraHeaders?: Record<string, string>) {
+  return new NextResponse(JSON.stringify(res), {
+    status,
+    headers: { "Content-Type": "application/json", ...(extraHeaders || {}) },
+  })
 }
 
 export async function POST(req: NextRequest) {
-  // --- Rate limit (10 req/min) por IP+UID ---
-  const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
-  const uidHeader = req.headers.get("x-user-id") || ""; // opcional si lo pasas desde el cliente
-  const scope = "games";
-  const rl = hitLimit(`${scope}:${ip}:${uidHeader}`, 10);
+  // --- Rate limit (10 req/min) por IP+UID (UID opcional) ---
+  const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown"
+  const uidHeader = req.headers.get("x-user-id") || ""
+  const rl = hitLimit(`games:${ip}:${uidHeader}`, 10)
   if (!rl.ok) {
-    return new NextResponse(JSON.stringify({ error: "rate_limited" }), {
-      status: 429,
-      headers: {
-        "Content-Type": "application/json",
-        "X-RateLimit-Remaining": String(rl.remaining),
-        "X-RateLimit-Reset": String(rl.reset),
-      },
-    });
+    return json(
+      { error: "rate_limited" },
+      429,
+      { "X-RateLimit-Remaining": String(rl.remaining), "X-RateLimit-Reset": String(rl.reset) }
+    )
   }
 
   try {
     // 1) Auth (Firebase ID token)
-    const authz = req.headers.get("authorization") || "";
-    const token = authz.startsWith("Bearer ") ? authz.slice(7) : undefined;
+    const authz = req.headers.get("authorization") || ""
+    const token = authz.startsWith("Bearer ") ? authz.slice(7) : undefined
     if (!token) {
-      return new NextResponse(JSON.stringify({ error: "missing_id_token" }), {
-        status: 401,
-        headers: {
-          "Content-Type": "application/json",
-          "X-RateLimit-Remaining": String(rl.remaining),
-          "X-RateLimit-Reset": String(rl.reset),
-        },
-      });
+      return json(
+        { error: "missing_id_token" },
+        401,
+        { "X-RateLimit-Remaining": String(rl.remaining), "X-RateLimit-Reset": String(rl.reset) }
+      )
     }
 
-    const decoded = await getAuth().verifyIdToken(token);
-    const uid = decoded.uid;             // Firebase UID (TEXT)
-    const email = decoded.email || null;
+    const decoded = await getAuth().verifyIdToken(token)
+    const uid = decoded.uid
+    const email = decoded.email || null
 
-    // 2) Body + validaciones
-    const body = await req.json().catch(() => ({}));
-    const { specialty, correct, total, duration_ms, opponent_elo } = body || {};
-
-    if (typeof specialty !== "string" || !specialty.trim()) {
-      return new NextResponse(JSON.stringify({ error: "missing_specialty" }), {
-        status: 400,
-        headers: {
-          "Content-Type": "application/json",
-          "X-RateLimit-Remaining": String(rl.remaining),
-          "X-RateLimit-Reset": String(rl.reset),
-        },
-      });
+    // 2) Body + validaciones estrictas
+    let body: any
+    try {
+      body = await req.json()
+    } catch {
+      return json(
+        { error: "invalid_json_body" },
+        400,
+        { "X-RateLimit-Remaining": String(rl.remaining), "X-RateLimit-Reset": String(rl.reset) }
+      )
     }
-    if (!Number.isFinite(correct) || !Number.isFinite(total)) {
-      return new NextResponse(JSON.stringify({ error: "score_not_numeric" }), {
-        status: 400,
-        headers: {
-          "Content-Type": "application/json",
-          "X-RateLimit-Remaining": String(rl.remaining),
-          "X-RateLimit-Reset": String(rl.reset),
-        },
-      });
+
+    const specialty = typeof body?.specialty === "string" ? body.specialty.trim() : ""
+    const correct = Number(body?.correct)
+    const total = Number(body?.total)
+    const duration_ms = Number(body?.duration_ms)
+    const opponent_elo = body?.opponent_elo != null ? Number(body.opponent_elo) : undefined
+
+    if (!specialty) {
+      return json(
+        { error: "missing_specialty" },
+        400,
+        { "X-RateLimit-Remaining": String(rl.remaining), "X-RateLimit-Reset": String(rl.reset) }
+      )
+    }
+    // enteros:
+    if (!Number.isInteger(correct) || !Number.isInteger(total)) {
+      return json(
+        { error: "correct_total_must_be_integers" },
+        400,
+        { "X-RateLimit-Remaining": String(rl.remaining), "X-RateLimit-Reset": String(rl.reset) }
+      )
     }
     if (total < 5 || correct < 0 || correct > total) {
-      return new NextResponse(JSON.stringify({ error: "invalid_score_bounds" }), {
-        status: 400,
-        headers: {
-          "Content-Type": "application/json",
-          "X-RateLimit-Remaining": String(rl.remaining),
-          "X-RateLimit-Reset": String(rl.reset),
-        },
-      });
+      return json(
+        { error: "invalid_score_bounds" },
+        400,
+        { "X-RateLimit-Remaining": String(rl.remaining), "X-RateLimit-Reset": String(rl.reset) }
+      )
+    }
+    if (!Number.isInteger(duration_ms) || duration_ms < 0) {
+      return json(
+        { error: "duration_ms_invalid" },
+        400,
+        { "X-RateLimit-Remaining": String(rl.remaining), "X-RateLimit-Reset": String(rl.reset) }
+      )
     }
 
-    // 3) Encontrar (o crear) el usuario
-    let userId: string = uid;
+    // 3) Encontrar (o crear) el usuario (id = Firebase UID por diseño)
+    let userId = uid
 
     let { data: userRow, error: userErr } = await supa
       .from("users")
       .select("id, elo, elo_by_specialty, email")
       .eq("id", uid)
-      .maybeSingle();
+      .maybeSingle()
 
-    if (userErr) {
-      return new NextResponse(JSON.stringify({ error: userErr.message }), {
-        status: 500,
-        headers: {
-          "Content-Type": "application/json",
-          "X-RateLimit-Remaining": String(rl.remaining),
-          "X-RateLimit-Reset": String(rl.reset),
-        },
-      });
-    }
+    if (userErr) return json(
+      { error: userErr.message },
+      500,
+      { "X-RateLimit-Remaining": String(rl.remaining), "X-RateLimit-Reset": String(rl.reset) }
+    )
 
     if (!userRow && email) {
       const { data: byEmail, error: emailErr } = await supa
         .from("users")
         .select("id, elo, elo_by_specialty, email")
         .eq("email", email)
-        .maybeSingle();
-
-      if (emailErr) {
-        return new NextResponse(JSON.stringify({ error: emailErr.message }), {
-          status: 500,
-          headers: {
-            "Content-Type": "application/json",
-            "X-RateLimit-Remaining": String(rl.remaining),
-            "X-RateLimit-Reset": String(rl.reset),
-          },
-        });
-      }
-
+        .maybeSingle()
+      if (emailErr) return json(
+        { error: emailErr.message },
+        500,
+        { "X-RateLimit-Remaining": String(rl.remaining), "X-RateLimit-Reset": String(rl.reset) }
+      )
       if (byEmail) {
-        userRow = byEmail;
-        userId = byEmail.id; // usa el id existente
+        userRow = byEmail
+        userId = byEmail.id
       }
     }
 
     if (!userRow) {
-      const { error: insUserErr } = await supa.from("users").insert({ id: uid, email, elo: 1200 });
-      if (insUserErr) {
-        return new NextResponse(JSON.stringify({ error: insUserErr.message }), {
-          status: 500,
-          headers: {
-            "Content-Type": "application/json",
-            "X-RateLimit-Remaining": String(rl.remaining),
-            "X-RateLimit-Reset": String(rl.reset),
-          },
-        });
-      }
+      const { error: insUserErr } = await supa.from("users").insert({ id: uid, email, elo: 1200, elo_by_specialty: {} })
+      if (insUserErr) return json(
+        { error: insUserErr.message },
+        500,
+        { "X-RateLimit-Remaining": String(rl.remaining), "X-RateLimit-Reset": String(rl.reset) }
+      )
       const reread = await supa
         .from("users")
         .select("id, elo, elo_by_specialty, email")
         .eq("id", uid)
-        .maybeSingle();
+        .maybeSingle()
       if (reread.error || !reread.data) {
-        return new NextResponse(JSON.stringify({ error: reread.error?.message || "user_create_read_failed" }), {
-          status: 500,
-          headers: {
-            "Content-Type": "application/json",
-            "X-RateLimit-Remaining": String(rl.remaining),
-            "X-RateLimit-Reset": String(rl.reset),
-          },
-        });
+        return json(
+          { error: reread.error?.message || "user_create_read_failed" },
+          500,
+          { "X-RateLimit-Remaining": String(rl.remaining), "X-RateLimit-Reset": String(rl.reset) }
+        )
       }
-      userRow = reread.data;
-      userId = userRow.id;
+      userRow = reread.data
+      userId = userRow.id
     }
 
-    // 4) Cálculo ELO (con clamp)
-    const bySpec = (userRow.elo_by_specialty as Record<string, number> | null) || {};
+    // 4) Cálculo ELO (con clamp y “oponente” 1500 por defecto)
+    const bySpec: Record<string, number> = (userRow.elo_by_specialty as any) ?? {}
     const currentElo =
-      (typeof bySpec[specialty] === "number" ? bySpec[specialty] : undefined) ??
-      (typeof userRow.elo === "number" ? userRow.elo : undefined) ??
-      1200;
+      (Number.isFinite(bySpec[specialty]) ? bySpec[specialty] : undefined) ??
+      (Number.isFinite(userRow.elo) ? userRow.elo : undefined) ??
+      1200
 
-    const score = correct / total;
-    const delta = calcEloDelta(currentElo, score, opponent_elo ?? 1500);
-    const newElo = currentElo + delta;
+    const score = correct / total
+    const delta = calcEloDelta(currentElo, score, Number.isFinite(opponent_elo!) ? opponent_elo : 1500)
+    const newElo = currentElo + delta
 
     // 5) Guardar partida
-    const { error: insGameErr } = await supa.from("game_sessions").insert({
-      user_id: userId,
-      specialty,
-      correct,
-      total,
-      duration_ms: Number.isFinite(duration_ms) ? duration_ms : null,
-    });
-    if (insGameErr) {
-      return new NextResponse(JSON.stringify({ error: insGameErr.message }), {
-        status: 500,
-        headers: {
-          "Content-Type": "application/json",
-          "X-RateLimit-Remaining": String(rl.remaining),
-          "X-RateLimit-Reset": String(rl.reset),
-        },
-      });
+    {
+      const { error: insGameErr } = await supa.from("game_sessions").insert({
+        user_id: userId,
+        specialty,
+        correct,
+        total,
+        duration_ms,
+      })
+      if (insGameErr) return json(
+        { error: insGameErr.message },
+        500,
+        { "X-RateLimit-Remaining": String(rl.remaining), "X-RateLimit-Reset": String(rl.reset) }
+      )
     }
 
     // 6) Historial ELO
-    const { error: insEloErr } = await supa.from("elo_history").insert({
-      user_id: userId,
-      specialty,
-      old_elo: currentElo,
-      delta,
-      new_elo: newElo,
-    });
-    if (insEloErr) {
-      return new NextResponse(JSON.stringify({ error: insEloErr.message }), {
-        status: 500,
-        headers: {
-          "Content-Type": "application/json",
-          "X-RateLimit-Remaining": String(rl.remaining),
-          "X-RateLimit-Reset": String(rl.reset),
-        },
-      });
+    {
+      const { error: insEloErr } = await supa.from("elo_history").insert({
+        user_id: userId,
+        specialty,
+        old_elo: currentElo,
+        delta,
+        new_elo: newElo,
+        correct,
+        total,
+        score,          // guarda score para auditoría
+        duration_ms,
+      })
+      if (insEloErr) return json(
+        { error: insEloErr.message },
+        500,
+        { "X-RateLimit-Remaining": String(rl.remaining), "X-RateLimit-Reset": String(rl.reset) }
+      )
     }
 
-    // 7) Actualizar usuario
-    const newBySpec = { ...(bySpec || {}) };
-    newBySpec[specialty] = newElo;
+    // 7) Actualizar usuario (JSON por especialidad + elo “global” opcional)
+    const newBySpec = { ...(bySpec || {}) }
+    newBySpec[specialty] = newElo
 
-    const { error: updErr } = await supa
-      .from("users")
-      .update({ elo: newElo, elo_by_specialty: newBySpec })
-      .eq("id", userId);
-    if (updErr) {
-      return new NextResponse(JSON.stringify({ error: updErr.message }), {
-        status: 500,
-        headers: {
-          "Content-Type": "application/json",
-          "X-RateLimit-Remaining": String(rl.remaining),
-          "X-RateLimit-Reset": String(rl.reset),
-        },
-      });
+    {
+      const { error: updErr } = await supa
+        .from("users")
+        .update({ elo: newElo, elo_by_specialty: newBySpec })
+        .eq("id", userId)
+      if (updErr) return json(
+        { error: updErr.message },
+        500,
+        { "X-RateLimit-Remaining": String(rl.remaining), "X-RateLimit-Reset": String(rl.reset) }
+      )
     }
 
-    // 8) Releer lo persistido (sanity)
-    const { data: userAfter, error: readAfterErr } = await supa
-      .from("users")
-      .select("elo, elo_by_specialty")
-      .eq("id", userId)
-      .maybeSingle();
-    if (readAfterErr) {
-      return new NextResponse(JSON.stringify({ error: readAfterErr.message }), {
-        status: 500,
-        headers: {
-          "Content-Type": "application/json",
-          "X-RateLimit-Remaining": String(rl.remaining),
-          "X-RateLimit-Reset": String(rl.reset),
-        },
-      });
-    }
-
-    const afterBySpec = (userAfter?.elo_by_specialty as Record<string, number> | null) || {};
-    const persistedAfter =
-      (typeof afterBySpec[specialty] === "number" ? afterBySpec[specialty] : undefined) ??
-      (typeof userAfter?.elo === "number" ? userAfter.elo : undefined) ??
-      null;
-
-    return new NextResponse(
-      JSON.stringify({
+    // 8) Respuesta
+    return json(
+      {
         ok: true,
         old_elo: currentElo,
         new_elo: newElo,
         delta,
         elo_after: newElo,
         elo_delta: delta,
-        persisted_elo_after: persistedAfter,
         user_id_used: userId,
-      }),
-      {
-        status: 200,
-        headers: {
-          "Content-Type": "application/json",
-          "X-RateLimit-Remaining": String(rl.remaining),
-          "X-RateLimit-Reset": String(rl.reset),
-        },
-      }
-    );
-  } catch (e: any) {
-    const msg = typeof e?.message === "string" ? e.message : "unexpected_error";
-    const code = msg.includes("Firebase ID token") || msg.includes("auth") ? 401 : 500;
-    return new NextResponse(JSON.stringify({ error: msg }), {
-      status: code,
-      headers: {
-        "Content-Type": "application/json",
-        "X-RateLimit-Remaining": "0", // conservador
       },
-    });
+      200,
+      { "X-RateLimit-Remaining": String(rl.remaining), "X-RateLimit-Reset": String(rl.reset) }
+    )
+  } catch (e: any) {
+    const msg = typeof e?.message === "string" ? e.message : "unexpected_error"
+    const code =
+      msg.includes("Firebase ID token") || msg.toLowerCase().includes("auth") ? 401 : 500
+    return json(
+      { error: msg },
+      code,
+      { "X-RateLimit-Remaining": "0" }
+    )
   }
 }

--- a/src/app/soloQ/page.tsx
+++ b/src/app/soloQ/page.tsx
@@ -1,31 +1,110 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { getAuth, onAuthStateChanged } from 'firebase/auth'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 
-type Q = { id: string; stem: string; options: string[]; specialty: string }
+type Q = {
+  id: string
+  stem: string
+  options: string[]
+  specialty: string
+  correctIndex: number // 0-based; -1 si desconocido
+}
+
+type SoloQState = 'loading' | 'playing' | 'finished' | 'error'
+
+const SECS_MIN = 25
+const SECS_MAX = 35
+
+// Si el backend ya baraja, puedes ponerlo en false.
+const SHUFFLE_CLIENT = true
+
+function randInt(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min + 1)) + min
+}
+function shuffle<T>(arr: T[]): T[] {
+  const a = arr.slice()
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[a[i], a[j]] = [a[j], a[i]]
+  }
+  return a
+}
+
+/** Normaliza el índice correcto desde múltiples formatos: 0/1-based, texto o máscara */
+function normalizeCorrectIndex(raw: any, options: any[]): number {
+  // numéricos con diferentes nombres
+  let ci: any =
+    raw.correctIndex ??
+    raw.correct_index ??
+    raw.answerIndex ??
+    raw.answer_index ??
+    raw.solutionIndex ??
+    raw.solution_index ??
+    null
+
+  // si venía como string numérico
+  if (typeof ci === 'string' && ci.trim() !== '') {
+    const n = Number(ci)
+    if (Number.isFinite(n)) ci = n
+  }
+
+  // 1‑based → 0‑based
+  if (typeof ci === 'number') {
+    let n = ci
+    if (n >= 1 && n <= options.length) n = n - 1
+    if (n >= 0 && n < options.length) return n
+  }
+
+  // por texto exacto
+  const textCandidate =
+    raw.correct_option ??
+    raw.correctValue ??
+    raw.answer ??
+    raw.solution ??
+    null
+  if (typeof textCandidate === 'string') {
+    const idx = options.findIndex(o => String(o) === String(textCandidate))
+    if (idx >= 0) return idx
+  }
+
+  // máscara booleana
+  if (Array.isArray(raw.correct_mask) && raw.correct_mask.length === options.length) {
+    const idx = raw.correct_mask.findIndex(Boolean)
+    if (idx >= 0) return idx
+  }
+
+  return -1
+}
 
 export default function SoloQPage() {
   const router = useRouter()
 
   const [uid, setUid] = useState<string | null>(null)
   const [email, setEmail] = useState<string | null>(null)
-
-  // id de tu fila en public.users (TEXT si usas Firebase UID)
   const [dbUserId, setDbUserId] = useState<string>('')
 
   const [specialty, setSpecialty] = useState<string>('neuro')
   const [qs, setQs] = useState<Q[]>([])
   const [idx, setIdx] = useState(0)
+
   const [selected, setSelected] = useState<number | null>(null)
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null)
   const [corrects, setCorrects] = useState<number>(0)
 
-  const [state, setState] = useState<'loading'|'playing'|'finished'|'error'>('loading')
+  const [state, setState] = useState<SoloQState>('loading')
   const [posting, setPosting] = useState(false)
   const [errMsg, setErrMsg] = useState<string>('')
+
+  // temporizador
+  const [secsLeft, setSecsLeft] = useState<number>(SECS_MAX)
+  const [allotted, setAllotted] = useState<number>(SECS_MAX)
+  const tickRef = useRef<number | null>(null)
+  const qStartRef = useRef<number | null>(null)
+  const runLockRef = useRef<boolean>(false) // anti doble‑clic/reentradas
+  const totalDurMsRef = useRef<number>(0)
 
   useEffect(() => {
     const auth = getAuth()
@@ -35,7 +114,6 @@ export default function SoloQPage() {
       setEmail(u.email ?? null)
 
       try {
-        // Cargar perfil (id + specialty) por UID
         const r = await fetch(`/api/me?uid=${encodeURIComponent(u.uid)}`, { cache: 'no-store' })
         if (r.ok) {
           const j = await r.json()
@@ -48,56 +126,140 @@ export default function SoloQPage() {
         setErrMsg('Error cargando tu perfil.')
       }
 
-      // Cargar 10 preguntas iniciales
-      const out = await fetch(`/api/questions?specialty=${encodeURIComponent(specialty)}&limit=10`, { cache: 'no-store' })
-      if (!out.ok) { setState('error'); return }
-      const { questions } = await out.json()
-      setQs(questions || [])
+      await loadQuestions(specialty)
       setState('playing')
     })
     return () => unsub()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Si specialty cambia tras /api/me, recargar preguntas una vez
+  // Recarga si cambia specialty tras /api/me
   useEffect(() => {
     (async () => {
       if (state !== 'playing' || !specialty) return
       if (qs.length > 0 && qs[0]?.specialty === specialty) return
-      const out = await fetch(`/api/questions?specialty=${encodeURIComponent(specialty)}&limit=10`, { cache: 'no-store' })
-      if (out.ok) {
-        const { questions } = await out.json()
-        setQs(questions || [])
-        setIdx(0)
-        setSelected(null)
-        setIsCorrect(null)
-        setCorrects(0)
-      }
+      await loadQuestions(specialty)
     })()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [specialty])
 
-  const current = qs[idx]
+  async function loadQuestions(spec: string) {
+    const out = await fetch(`/api/questions?specialty=${encodeURIComponent(spec)}&limit=10`, { cache: 'no-store' })
+    if (!out.ok) { setState('error'); return }
+    const { questions } = await out.json()
 
-  async function onSelect(i: number) {
-    if (!current || selected != null) return
-    setSelected(i)
-    try {
-      const res = await fetch('/api/answer', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ questionId: current.id, selectedIndex: i })
-      })
-      const json = await res.json()
-      const ok = !!json?.correct
-      setIsCorrect(ok)
-      if (ok) setCorrects(c => c + 1)
-    } catch {
-      setIsCorrect(false)
-    }
+    const typed: Q[] = (questions || []).map((raw: any) => {
+      const options = Array.isArray(raw.options) ? raw.options.slice() : []
+      const ci = normalizeCorrectIndex(raw, options)
+      return {
+        id: String(raw.id),
+        stem: String(raw.stem),
+        options,
+        specialty: raw.specialty ?? spec,
+        correctIndex: ci,
+      }
+    })
+
+    // Evitar desalinear la correcta: solo barajamos si TODOS tienen índice válido
+    const canShuffle = SHUFFLE_CLIENT && typed.every(q => q.correctIndex >= 0)
+    const base = canShuffle ? shuffle(typed) : typed
+    const finalQs = canShuffle
+      ? base.map(q => {
+          const idxs = q.options.map((_, i) => i)
+          const perm = shuffle(idxs)
+          const newOptions = perm.map(i => q.options[i])
+          const newCorrect = perm.findIndex(i => i === q.correctIndex)
+          return { ...q, options: newOptions, correctIndex: newCorrect }
+        })
+      : base
+
+    clearTimer()
+    setQs(finalQs)
+    setIdx(0)
+    setSelected(null)
+    setIsCorrect(null)
+    setCorrects(0)
+    primeTimer()
   }
 
-  // 🔐 Utilidad: obtener ID token o lanzar error claro
+  const current = qs[idx]
+
+  // temporizador
+  function clearTimer() {
+    if (tickRef.current != null) {
+      window.clearInterval(tickRef.current)
+      tickRef.current = null
+    }
+  }
+  function primeTimer() {
+    clearTimer()
+    const allot = randInt(SECS_MIN, SECS_MAX)
+    setAllotted(allot)
+    setSecsLeft(allot)
+    qStartRef.current = Date.now()
+    runLockRef.current = false
+    tickRef.current = window.setInterval(() => {
+      setSecsLeft((s) => {
+        if (s <= 1) {
+          window.clearInterval(tickRef.current!)
+          tickRef.current = null
+          if (!runLockRef.current) {
+            runLockRef.current = true
+            onTimeout()
+          }
+          return 0
+        }
+        return s - 1
+      })
+    }, 1000)
+  }
+  function onTimeout() {
+    if (qStartRef.current) {
+      totalDurMsRef.current += Date.now() - qStartRef.current
+      qStartRef.current = null
+    }
+    setSelected(-1) // sin selección
+    setIsCorrect(false)
+  }
+
+  // selección con fallback a /api/answer si no hay índice fiable
+  async function onSelect(i: number) {
+    if (!current || selected != null || runLockRef.current) return
+    runLockRef.current = true
+    clearTimer()
+
+    if (qStartRef.current) {
+      totalDurMsRef.current += Date.now() - qStartRef.current
+      qStartRef.current = null
+    }
+
+    setSelected(i)
+
+    let ok = false
+    if (current.correctIndex >= 0 && current.correctIndex < current.options.length) {
+      ok = i === current.correctIndex
+    } else {
+      try {
+        const res = await fetch('/api/answer', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ questionId: current.id, selectedIndex: i }),
+        })
+        const json = await res.json()
+        ok = !!json?.correct
+        if (typeof json?.correctIndex === 'number') {
+          current.correctIndex = json.correctIndex // opcional: cachear
+        }
+      } catch {
+        ok = false
+      }
+    }
+
+    setIsCorrect(ok)
+    if (ok) setCorrects(c => c + 1)
+  }
+
+  // auth token
   async function getIdTokenOrThrow() {
     const auth = getAuth()
     const user = auth.currentUser
@@ -105,85 +267,76 @@ export default function SoloQPage() {
     return user.getIdToken()
   }
 
-  async function next() {
-    if (selected == null || posting) return
-
+  function goNext() {
+    if (posting) return
     if (idx < qs.length - 1) {
       setIdx(i => i + 1)
       setSelected(null)
       setIsCorrect(null)
+      runLockRef.current = false
+      primeTimer()
     } else {
-      // Fin: cerrar partida → /resultados
-      try {
-        setPosting(true)
-        setState('finished')
-
-        const finalCorrects = corrects // ya actualizado en onSelect
-
-        if (!specialty) {
-          setErrMsg('No hay especialidad definida.')
-          return
-        }
-
-        // ⬇️⬇️ CAMBIO CLAVE: añadir Authorization: Bearer <ID_TOKEN> ⬇️⬇️
-        const idToken = await getIdTokenOrThrow()
-
-        // El backend ignora user_id/email y usa uid del token verificado
-        const payload = {
-          specialty,
-          correct: finalCorrects,
-          total: qs.length,
-          // opcional: duration_ms si lo calculas
-        }
-
-        const r = await fetch('/api/games', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${idToken}`, // 👈 necesarios para evitar missing_id_token
-          },
-          body: JSON.stringify(payload),
-        })
-
-        const j = await r.json()
-        if (!r.ok) throw new Error(j.error || 'Error al cerrar partida')
-
-
-      
-        console.log('[SoloQ -> Resultados]', {
-          delta: j.delta ?? j.elo_delta,
-          new_elo: j.new_elo ?? j.elo_after,
-          correct: finalCorrects,
-          total: qs.length,
-          specialty,
-        });
-        
-        // Construir query con los datos que vienen del backend + tus cálculos
-        const q = new URLSearchParams({
-          eloDelta: String(j.delta ?? j.elo_delta ?? 0),
-          eloAfter: String(j.new_elo ?? j.elo_after ?? ''),
-          correct: String(finalCorrects),
-          total: String(qs.length),
-          specialty,
-        });
-        // Redirigir a la página de resultados
-        router.push(`/resultados?${q.toString()}`);
-
-      } catch (e: any) {
-        console.error(e)
-        setErrMsg(e?.message || 'Error al cerrar partida')
-        setState('finished')
-      } finally {
-        setPosting(false)
-      }
+      finalize()
     }
   }
 
+  async function finalize() {
+    try {
+      setPosting(true)
+      setState('finished')
+
+      if (!specialty) {
+        setErrMsg('No hay especialidad definida.')
+        return
+      }
+
+      clearTimer()
+      if (qStartRef.current) {
+        totalDurMsRef.current += Date.now() - qStartRef.current
+        qStartRef.current = null
+      }
+
+      const idToken = await getIdTokenOrThrow()
+      const payload = {
+        specialty,
+        correct: corrects,
+        total: qs.length,
+        duration_ms: Math.max(0, Math.round(totalDurMsRef.current)),
+      }
+
+      const r = await fetch('/api/games', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${idToken}`,
+        },
+        body: JSON.stringify(payload),
+      })
+      const j = await r.json()
+      if (!r.ok) throw new Error(j.error || 'Error al cerrar partida')
+
+      const q = new URLSearchParams({
+        eloDelta: String(j.delta ?? j.elo_delta ?? 0),
+        eloAfter: String(j.new_elo ?? j.elo_after ?? ''),
+        correct: String(corrects),
+        total: String(qs.length),
+        specialty,
+      })
+      router.push(`/resultados?${q.toString()}`)
+    } catch (e: any) {
+      console.error(e)
+      setErrMsg(e?.message || 'Error al cerrar partida')
+      setState('finished')
+    } finally {
+      setPosting(false)
+    }
+  }
+
+  // UI
   if (state === 'loading') return <div className="p-6">Preparando tu SoloQ…</div>
   if (state === 'error') return <div className="p-6">Error de sesión o carga. <Link className="underline" href="/login">Inicia sesión</Link></div>
 
   if (state === 'finished') {
-    // Fallback mientras redirige o si hubo error
     return (
       <div className="p-6 space-y-4">
         <h1 className="text-2xl font-semibold">¡Partida terminada!</h1>
@@ -206,7 +359,10 @@ export default function SoloQPage() {
           <h1 className="text-xl font-semibold">SoloQ – {specialty}</h1>
           <p className="text-sm text-gray-500">Pregunta {idx + 1} de {qs.length}</p>
         </div>
-        <div className="text-sm text-gray-500">Aciertos: {corrects}</div>
+        <div className="flex items-center gap-4 text-sm text-gray-600">
+          <span>Aciertos: {corrects}</span>
+          <span>⏱ {secsLeft}s</span>
+        </div>
       </header>
 
       <section className="border rounded-lg p-5">
@@ -222,7 +378,8 @@ export default function SoloQPage() {
                   'w-full text-left border rounded-md px-4 py-3 transition',
                   isSel ? 'ring-2 ring-blue-500' : '',
                   selected != null && isSel && isCorrect === true ? 'bg-green-50 border-green-400' : '',
-                  selected != null && isSel && isCorrect === false ? 'bg-red-50 border-red-400' : ''
+                  selected != null && isSel && isCorrect === false ? 'bg-red-50 border-red-400' : '',
+                  runLockRef.current ? 'pointer-events-none opacity-90' : ''
                 ].join(' ')}
                 disabled={selected != null}
               >
@@ -232,20 +389,25 @@ export default function SoloQPage() {
           })}
         </div>
 
-        {selected != null && (
-          <div className="mt-4 flex items-center justify-between">
-            <p className={`text-sm ${isCorrect ? 'text-green-600' : 'text-red-600'}`}>
-              {isCorrect ? '¡Correcto!' : 'Incorrecto'}
-            </p>
-            <button
-              onClick={next}
-              disabled={posting}
-              className="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
-            >
-              {idx < qs.length - 1 ? 'Siguiente' : (posting ? 'Guardando…' : 'Finalizar')}
-            </button>
-          </div>
-        )}
+        <div className="mt-4 flex items-center justify-between">
+          <p className="text-sm text-gray-500">Tiempo asignado: {allotted}s</p>
+          {(selected != null || secsLeft === 0) && (
+            <div className="flex items-center gap-3">
+              {selected != null && (
+                <span className={`text-sm ${isCorrect ? 'text-green-600' : (selected === -1 ? 'text-orange-600' : 'text-red-600')}`}>
+                  {isCorrect ? '¡Correcto!' : (selected === -1 ? 'Tiempo agotado' : 'Incorrecto')}
+                </span>
+              )}
+              <button
+                onClick={goNext}
+                disabled={posting}
+                className="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
+              >
+                {idx < qs.length - 1 ? 'Siguiente' : (posting ? 'Guardando…' : 'Finalizar')}
+              </button>
+            </div>
+          )}
+        </div>
       </section>
     </div>
   )


### PR DESCRIPTION
## 🎯 DW#2 — SoloQ fino + ELO fiable  

### ✅ Qué hicimos
- **Frontend SoloQ**
  - Temporizador por pregunta (25–35 s) con auto-timeout.  
  - Bloqueo de doble clic y anti-reentradas.  
  - Corrección de respuestas robusta gracias a normalización de `correctIndex`.  
  - Al finalizar partida → envío de resultados a `/api/games` con Bearer token.  

- **Backend `/api/games`**
  - Validación de Firebase ID token → solo usuarios logueados pueden cerrar partidas.  
  - Validaciones de payload:  
    - `total ≥ 5`  
    - `0 ≤ correct ≤ total`  
    - `duration_ms ≥ 0`  
  - Cálculo de **ELO delta** con fórmula estándar + clamp [-40, +40].  
  - Inserción en tablas:  
    - `game_sessions` → historial de partidas.  
    - `elo_history` → historial de variaciones de ELO.  
  - Actualización de `users.elo` y `elo_by_specialty`.  

- **Base de datos**
  - Añadidas columnas faltantes en `elo_history` (`correct`, `total`, `score`, `duration_ms`).  
  - RLS activado + políticas para que cada usuario solo vea sus propios datos.  

---

### 📌 Utilidad
- **Juego realista** → partidas con límite de tiempo y flujo robusto.  
- **Datos consistentes** → cada partida queda registrada con resultado, duración y ELO asociado.  
- **Seguridad** → imposible falsificar partidas sin token válido.  
- **Progresión justa** → ELO estable, evitando saltos absurdos.  
- **Histórico listo** → datos preparados para gráficas de evolución y rankings por especialidad.  

---

✔️ Con este DW#2, el sistema SoloQ ya está **funcionando de extremo a extremo**:  
juegas → terminas → se calcula y guarda ELO → vuelves al front con tu variación.
